### PR TITLE
Bugfix/node fetch fails on version above 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "express": "^4.17.3",
-    "node-fetch": "^3.2.3",
+    "node-fetch": "2.6.6",
     "routing-controllers": "^0.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
It appears that node-fetch version above 3.0.0 fails to work with typescript. 
node-fetch version was downgraded in Scope of that PR:
Question raised in stackoverflow (2 answer):
https://stackoverflow.com/questions/69041454/error-require-of-es-modules-is-not-supported-when-importing-node-fetch

